### PR TITLE
Add tab bar

### DIFF
--- a/lib/Models/widgetModel.dart
+++ b/lib/Models/widgetModel.dart
@@ -3,9 +3,11 @@ import 'package:flutter/widgets.dart';
 class WidgetModel {
   final String name, subtitle;
   final Widget sample;
+  final Widget sampleDescription;
   const WidgetModel({
     required this.name,
     this.subtitle = '',
     required this.sample,
+    required this.sampleDescription,
   });
 }

--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -1,4 +1,5 @@
 import 'package:fludget/Models/widgetModel.dart';
+import 'package:fludget/routes/Root/rootScreen.dart';
 import 'package:fludget/routes/button.dart';
 import 'package:fludget/routes/dialogBox.dart';
 import 'package:fludget/routes/column.dart';
@@ -184,7 +185,10 @@ class HomePageState extends State<HomePage> {
         Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (_) => item.sample,
+            builder: (_) => RootScreen(
+              widgetImplementation: item.sample,
+              widgetName: item.name,
+            ),
           ),
         );
       },

--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -88,30 +88,46 @@ class HomePageState extends State<HomePage> {
 
   ListView getWidgetList(String filter) {
     const List<WidgetModel> widgets = [
-      WidgetModel(name: "Column", sample: ColumnSample()),
-      WidgetModel(name: "Row", sample: RowSample()),
-      WidgetModel(name: "Stack", sample: StackSample()),
-      WidgetModel(name: "Text", sample: TextSample()),
-      WidgetModel(name: "Icon", sample: IconSample()),
       WidgetModel(
-        name: "Image",
-        subtitle: "Asset Image, Network Image",
-        sample: ImageSample(),
-      ),
+          name: "Column",
+          sample: ColumnSample(),
+          sampleDescription: ColumnDescription()),
       WidgetModel(
-        name: "Button",
-        subtitle: "Elevated Button, Text Button, Floating Action Button",
-        sample: ButtonSample(),
-      ),
+          name: "Row",
+          sample: RowSample(),
+          sampleDescription: RowWidgetDescription()),
       WidgetModel(
-        name: "DialogBox",
-        subtitle: "shows Dialog",
-        sample: DialogBox(),
-      ),
+          name: "Stack",
+          sample: StackSample(),
+          sampleDescription: StackWidgetDescription()),
+      WidgetModel(
+          name: "Text",
+          sample: TextSample(),
+          sampleDescription: TextWidgetDescription()),
+      WidgetModel(
+          name: "Icon",
+          sample: IconSample(),
+          sampleDescription: IconWidgetDescription()),
+      WidgetModel(
+          name: "Image",
+          subtitle: "Asset Image, Network Image",
+          sample: ImageSample(),
+          sampleDescription: ImageWidgetDescription()),
+      WidgetModel(
+          name: "Button",
+          subtitle: "Elevated Button, Text Button, Floating Action Button",
+          sample: ButtonSample(),
+          sampleDescription: ButtonDescription()),
+      WidgetModel(
+          name: "DialogBox",
+          subtitle: "shows Dialog",
+          sample: DialogBox(),
+          sampleDescription: DialogBoxDescription()),
       WidgetModel(
         name: "GridList",
         subtitle: "shows Dialog",
         sample: GridListSample(),
+        sampleDescription: GridListDescription(),
       ),
     ];
 
@@ -188,6 +204,7 @@ class HomePageState extends State<HomePage> {
             builder: (_) => RootScreen(
               widgetImplementation: item.sample,
               widgetName: item.name,
+              widgetDescription: item.sampleDescription,
             ),
           ),
         );

--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -68,6 +68,7 @@ class HomePageState extends State<HomePage> {
       appBar: searching
           ? showSearchBar()
           : AppBar(
+              backgroundColor: Colors.orange[900],
               title: Text("Widget Catalog"),
               actions: [
                 IconButton(

--- a/lib/routes/Root/rootScreen.dart
+++ b/lib/routes/Root/rootScreen.dart
@@ -34,10 +34,17 @@ class _RootScreenState extends State<RootScreen> {
         body: TabBarView(
           children: [
             widget.widgetImplementation,
-            widget.widgetDescription,
+            buildWidgetDescription(widget.widgetDescription),
           ],
         ),
       ),
     );
   }
+}
+
+Widget buildWidgetDescription(Widget widgetDescription) {
+  return Scaffold(
+    backgroundColor: Colors.grey[900],
+    body: widgetDescription,
+  );
 }

--- a/lib/routes/Root/rootScreen.dart
+++ b/lib/routes/Root/rootScreen.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class RootScreen extends StatefulWidget {
+  Widget widgetImplementation;
+  final String widgetName;
+
+  RootScreen({
+    Key? key,
+    required this.widgetImplementation,
+    required this.widgetName,
+  }) : super(key: key);
+
+  @override
+  _RootScreenState createState() => _RootScreenState();
+}
+
+class _RootScreenState extends State<RootScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(widget.widgetName),
+          bottom: TabBar(
+            tabs: [
+              Tab(text: 'Implementation'),
+              Tab(text: 'Description'),
+            ],
+          ),
+        ),
+        body: TabBarView(children: [
+          widget.widgetImplementation,
+          Center(
+            child: Text('${widget.widgetName} Implementation'),
+          )
+        ]),
+      ),
+    );
+  }
+}

--- a/lib/routes/Root/rootScreen.dart
+++ b/lib/routes/Root/rootScreen.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
 
 class RootScreen extends StatefulWidget {
-  Widget widgetImplementation;
+  final Widget widgetImplementation;
+  final Widget widgetDescription;
   final String widgetName;
 
   RootScreen({
     Key? key,
     required this.widgetImplementation,
     required this.widgetName,
+    required this.widgetDescription,
   }) : super(key: key);
 
   @override
@@ -29,12 +31,12 @@ class _RootScreenState extends State<RootScreen> {
             ],
           ),
         ),
-        body: TabBarView(children: [
-          widget.widgetImplementation,
-          Center(
-            child: Text('${widget.widgetName} Implementation'),
-          )
-        ]),
+        body: TabBarView(
+          children: [
+            widget.widgetImplementation,
+            widget.widgetDescription,
+          ],
+        ),
       ),
     );
   }

--- a/lib/routes/Root/rootScreen.dart
+++ b/lib/routes/Root/rootScreen.dart
@@ -23,6 +23,7 @@ class _RootScreenState extends State<RootScreen> {
       length: 2,
       child: Scaffold(
         appBar: AppBar(
+          backgroundColor: Colors.orange[900],
           title: Text(widget.widgetName),
           bottom: TabBar(
             tabs: [

--- a/lib/routes/button.dart
+++ b/lib/routes/button.dart
@@ -72,3 +72,20 @@ void _message(BuildContext context) =>
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
       content: Text("Button was pressed"),
     ));
+
+class ButtonDescription extends StatelessWidget {
+  const ButtonDescription({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[900],
+      body: Center(
+        child: Text(
+          'Button Description Here',
+          style: TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/button.dart
+++ b/lib/routes/button.dart
@@ -78,13 +78,10 @@ class ButtonDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.grey[900],
-      body: Center(
-        child: Text(
-          'Button Description Here',
-          style: TextStyle(color: Colors.white),
-        ),
+    return Center(
+      child: Text(
+        'Button Description Here',
+        style: TextStyle(color: Colors.white),
       ),
     );
   }

--- a/lib/routes/button.dart
+++ b/lib/routes/button.dart
@@ -6,9 +6,9 @@ class ButtonSample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text("Buttons"),
-      ),
+      // appBar: AppBar(
+      //   title: Text("Buttons"),
+      // ),
       backgroundColor: Colors.grey[900],
       body: Padding(
         padding: const EdgeInsets.all(15.0),

--- a/lib/routes/column.dart
+++ b/lib/routes/column.dart
@@ -47,3 +47,20 @@ class ColumnSample extends StatelessWidget {
     );
   }
 }
+
+class ColumnDescription extends StatelessWidget {
+  const ColumnDescription({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[900],
+      body: Center(
+        child: Text(
+          'Column Description Here',
+          style: TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/column.dart
+++ b/lib/routes/column.dart
@@ -53,13 +53,10 @@ class ColumnDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.grey[900],
-      body: Center(
-        child: Text(
-          'Column Description Here',
-          style: TextStyle(color: Colors.white),
-        ),
+    return Center(
+      child: Text(
+        'Column Description Here',
+        style: TextStyle(color: Colors.white),
       ),
     );
   }

--- a/lib/routes/column.dart
+++ b/lib/routes/column.dart
@@ -6,9 +6,9 @@ class ColumnSample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text("Column"),
-      ),
+      // appBar: AppBar(
+      //   title: Text("Column"),
+      // ),
       backgroundColor: Colors.grey[900],
       body: Padding(
         padding: const EdgeInsets.all(15.0),

--- a/lib/routes/dialogBox.dart
+++ b/lib/routes/dialogBox.dart
@@ -70,13 +70,10 @@ class DialogBoxDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.grey[900],
-      body: Center(
-        child: Text(
-          'Dialog Box Description Here',
-          style: TextStyle(color: Colors.white),
-        ),
+    return Center(
+      child: Text(
+        'Dialog Box Description Here',
+        style: TextStyle(color: Colors.white),
       ),
     );
   }

--- a/lib/routes/dialogBox.dart
+++ b/lib/routes/dialogBox.dart
@@ -30,9 +30,9 @@ class DialogBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text("Dialog Widget"),
-      ),
+      // appBar: AppBar(
+      //   title: Text("Dialog Widget"),
+      // ),
       backgroundColor: Colors.grey[900],
       body: Padding(
         padding: const EdgeInsets.all(15.0),

--- a/lib/routes/dialogBox.dart
+++ b/lib/routes/dialogBox.dart
@@ -64,3 +64,20 @@ class DialogBox extends StatelessWidget {
     );
   }
 }
+
+class DialogBoxDescription extends StatelessWidget {
+  const DialogBoxDescription({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[900],
+      body: Center(
+        child: Text(
+          'Dialog Box Description Here',
+          style: TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/gridList.dart
+++ b/lib/routes/gridList.dart
@@ -6,9 +6,9 @@ class GridListSample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text("GridList"),
-      ),
+      // appBar: AppBar(
+      //   title: Text("GridList"),
+      // ),
       backgroundColor: Colors.grey[900],
       body: Padding(
         padding: const EdgeInsets.all(15.0),

--- a/lib/routes/gridList.dart
+++ b/lib/routes/gridList.dart
@@ -52,3 +52,20 @@ class GridListSample extends StatelessWidget {
     );
   }
 }
+
+class GridListDescription extends StatelessWidget {
+  const GridListDescription({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[900],
+      body: Center(
+        child: Text(
+          'Grid List Description Here',
+          style: TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/gridList.dart
+++ b/lib/routes/gridList.dart
@@ -58,13 +58,10 @@ class GridListDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.grey[900],
-      body: Center(
-        child: Text(
-          'Grid List Description Here',
-          style: TextStyle(color: Colors.white),
-        ),
+    return Center(
+      child: Text(
+        'Grid List Description Here',
+        style: TextStyle(color: Colors.white),
       ),
     );
   }

--- a/lib/routes/icon.dart
+++ b/lib/routes/icon.dart
@@ -32,3 +32,20 @@ class IconSample extends StatelessWidget {
     );
   }
 }
+
+class IconWidgetDescription extends StatelessWidget {
+  const IconWidgetDescription({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[900],
+      body: Center(
+        child: Text(
+          'Icon Description Here',
+          style: TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/icon.dart
+++ b/lib/routes/icon.dart
@@ -38,13 +38,10 @@ class IconWidgetDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.grey[900],
-      body: Center(
-        child: Text(
-          'Icon Description Here',
-          style: TextStyle(color: Colors.white),
-        ),
+    return Center(
+      child: Text(
+        'Icon Description Here',
+        style: TextStyle(color: Colors.white),
       ),
     );
   }

--- a/lib/routes/icon.dart
+++ b/lib/routes/icon.dart
@@ -6,9 +6,9 @@ class IconSample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text("Icon"),
-      ),
+      // appBar: AppBar(
+      //   title: Text("Icon"),
+      // ),
       backgroundColor: Colors.grey[900],
       body: Center(
         child: Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: [

--- a/lib/routes/image.dart
+++ b/lib/routes/image.dart
@@ -48,13 +48,10 @@ class ImageWidgetDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.grey[900],
-      body: Center(
-        child: Text(
-          'Image Description Here',
-          style: TextStyle(color: Colors.white),
-        ),
+    return Center(
+      child: Text(
+        'Image Description Here',
+        style: TextStyle(color: Colors.white),
       ),
     );
   }

--- a/lib/routes/image.dart
+++ b/lib/routes/image.dart
@@ -6,9 +6,9 @@ class ImageSample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text("Image"),
-      ),
+      // appBar: AppBar(
+      //   title: Text("Image"),
+      // ),
       backgroundColor: Colors.grey[900],
       body: Padding(
         padding: const EdgeInsets.all(10.0),

--- a/lib/routes/image.dart
+++ b/lib/routes/image.dart
@@ -42,3 +42,20 @@ class ImageSample extends StatelessWidget {
     );
   }
 }
+
+class ImageWidgetDescription extends StatelessWidget {
+  const ImageWidgetDescription({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[900],
+      body: Center(
+        child: Text(
+          'Image Description Here',
+          style: TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/row.dart
+++ b/lib/routes/row.dart
@@ -6,9 +6,9 @@ class RowSample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text("Row"),
-      ),
+      // appBar: AppBar(
+      //   title: Text("Row"),
+      // ),
       backgroundColor: Colors.grey[900],
       body: Padding(
         padding: const EdgeInsets.all(10.0),

--- a/lib/routes/row.dart
+++ b/lib/routes/row.dart
@@ -47,3 +47,20 @@ class RowSample extends StatelessWidget {
     );
   }
 }
+
+class RowWidgetDescription extends StatelessWidget {
+  const RowWidgetDescription({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[900],
+      body: Center(
+        child: Text(
+          'Row Description Here',
+          style: TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/row.dart
+++ b/lib/routes/row.dart
@@ -53,13 +53,10 @@ class RowWidgetDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.grey[900],
-      body: Center(
-        child: Text(
-          'Row Description Here',
-          style: TextStyle(color: Colors.white),
-        ),
+    return Center(
+      child: Text(
+        'Row Description Here',
+        style: TextStyle(color: Colors.white),
       ),
     );
   }

--- a/lib/routes/stack.dart
+++ b/lib/routes/stack.dart
@@ -46,3 +46,20 @@ class StackSample extends StatelessWidget {
     );
   }
 }
+
+class StackWidgetDescription extends StatelessWidget {
+  const StackWidgetDescription({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[900],
+      body: Center(
+        child: Text(
+          'Stack Description Here',
+          style: TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/stack.dart
+++ b/lib/routes/stack.dart
@@ -6,9 +6,9 @@ class StackSample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text("Stack"),
-      ),
+      // appBar: AppBar(
+      //   title: Text("Stack"),
+      // ),
       backgroundColor: Colors.grey[900],
       body: Padding(
         padding: const EdgeInsets.all(10.0),

--- a/lib/routes/stack.dart
+++ b/lib/routes/stack.dart
@@ -52,13 +52,10 @@ class StackWidgetDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.grey[900],
-      body: Center(
-        child: Text(
-          'Stack Description Here',
-          style: TextStyle(color: Colors.white),
-        ),
+    return Center(
+      child: Text(
+        'Stack Description Here',
+        style: TextStyle(color: Colors.white),
       ),
     );
   }

--- a/lib/routes/text.dart
+++ b/lib/routes/text.dart
@@ -21,3 +21,20 @@ class TextSample extends StatelessWidget {
     );
   }
 }
+
+class TextWidgetDescription extends StatelessWidget {
+  const TextWidgetDescription({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[900],
+      body: Center(
+        child: Text(
+          'Text Description Here',
+          style: TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/text.dart
+++ b/lib/routes/text.dart
@@ -27,13 +27,10 @@ class TextWidgetDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.grey[900],
-      body: Center(
-        child: Text(
-          'Text Description Here',
-          style: TextStyle(color: Colors.white),
-        ),
+    return Center(
+      child: Text(
+        'Text Description Here',
+        style: TextStyle(color: Colors.white),
       ),
     );
   }

--- a/lib/routes/text.dart
+++ b/lib/routes/text.dart
@@ -6,9 +6,9 @@ class TextSample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text("Text"),
-      ),
+      // appBar: AppBar(
+      //   title: Text("Text"),
+      // ),
       backgroundColor: Colors.grey[900],
       body: Center(
         heightFactor: 15,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Referring to Issue #16 
Enhancement: Added tab  bar when viewing the widgets, rather than adding to all the widgets. i've made it as follows:

- A RootScreen - added tabs in the root screen which takes the widget through constructors and displays selected widget.
- by this, the one who makes widget must not care about making tab bars, but can simply go on by creating the widget.
-  and also: Add your own custom Description class which will then be automatically passed through constructors.

And here are the screenshots.
![first](https://user-images.githubusercontent.com/80746702/135748617-71c35529-5285-4f92-b374-8d34a3265ac8.PNG)

![second](https://user-images.githubusercontent.com/80746702/135748621-167f5035-7402-495d-a778-034ed6fc1f0a.PNG)

![third](https://user-images.githubusercontent.com/80746702/135748629-5835940d-7eef-4cd3-b538-8841afad0936.PNG)

 