### PR TITLE
Add floating action button in widget implementation screen

### DIFF
--- a/android/settings_aar.gradle
+++ b/android/settings_aar.gradle
@@ -1,0 +1,1 @@
+include ':app'

--- a/lib/Models/widgetModel.dart
+++ b/lib/Models/widgetModel.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/widgets.dart';
 
 class WidgetModel {
-  final String name, subtitle;
-  final Widget sample;
-  final Widget sampleDescription;
+  final String name, subtitle, link;
+  final Widget implementation;
+  final Widget description;
   const WidgetModel({
     required this.name,
     this.subtitle = '',
-    required this.sample,
-    required this.sampleDescription,
+    required this.link,
+    required this.implementation,
+    required this.description,
   });
 }

--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -98,69 +98,95 @@ class HomePageState extends State<HomePage> {
   ListView getWidgetList(String filter) {
     const List<WidgetModel> widgets = [
       WidgetModel(
-          name: "Column",
-          sample: ColumnSample(),
-          sampleDescription: ColumnDescription()),
+        name: "Column",
+        implementation: ColumnImplementation(),
+        description: ColumnDescription(),
+        link: "https://api.flutter.dev/flutter/widgets/Column-class.html",
+      ),
       WidgetModel(
-          name: "Row",
-          sample: RowSample(),
-          sampleDescription: RowWidgetDescription()),
+        name: "Row",
+        implementation: RowImplementation(),
+        description: RowDescription(),
+        link: "https://api.flutter.dev/flutter/widgets/Row-class.html",
+      ),
       WidgetModel(
-          name: "Stack",
-          sample: StackSample(),
-          sampleDescription: StackWidgetDescription()),
+        name: "Stack",
+        implementation: StackImplementation(),
+        description: StackDescription(),
+        link: "https://api.flutter.dev/flutter/widgets/Stack-class.html",
+      ),
       WidgetModel(
-          name: "Text",
-          sample: TextSample(),
-          sampleDescription: TextWidgetDescription()),
+        name: "Text",
+        implementation: TextImplementation(),
+        description: TextDescription(),
+        link: "https://api.flutter.dev/flutter/widgets/Text-class.html",
+      ),
       WidgetModel(
-          name: "Icon",
-          sample: IconSample(),
-          sampleDescription: IconWidgetDescription()),
+        name: "Icon",
+        implementation: IconImplementation(),
+        description: IconDescription(),
+        link: "https://api.flutter.dev/flutter/widgets/Icon-class.html",
+      ),
       WidgetModel(
-          name: "Image",
-          subtitle: "Asset Image, Network Image",
-          sample: ImageSample(),
-          sampleDescription: ImageWidgetDescription()),
+        name: "Image",
+        subtitle: "Asset Image, Network Image",
+        implementation: ImageImplementation(),
+        description: ImageDescription(),
+        link: "https://api.flutter.dev/flutter/widgets/Image-class.html",
+      ),
       WidgetModel(
-          name: "Button",
-          subtitle: "Elevated Button, Text Button, Floating Action Button",
-          sample: ButtonSample(),
-          sampleDescription: ButtonDescription()),
+        name: "Button",
+        subtitle: "Elevated Button, Text Button, Floating Action Button",
+        implementation: ButtonImplementation(),
+        description: ButtonDescription(),
+        link:
+            "https://api.flutter.dev/flutter/material/ElevatedButton-class.html",
+      ),
       WidgetModel(
-          name: "DialogBox",
-          subtitle: "shows Dialog",
-          sample: DialogBox(),
-          sampleDescription: DialogBoxDescription()),
+        name: "DialogBox",
+        subtitle: "shows Dialog",
+        implementation: DialogBoxImplementation(),
+        description: DialogBoxDescription(),
+        link: "https://api.flutter.dev/flutter/material/AlertDialog-class.html",
+      ),
       WidgetModel(
         name: "GridList",
-        subtitle: "shows Dialog",
-        sample: GridListSample(),
-        sampleDescription: GridListDescription(),
+        implementation: GridListImplementation(),
+        description: GridListDescription(),
+        link: "https://api.flutter.dev/flutter/widgets/GridView-class.html",
       ),
       WidgetModel(
         name: "Switch",
         subtitle: "Toggle Switch",
-        sample: SwitchSample(),
-        sampleDescription: SwitchDescription(),
+        implementation: SwitchImplementation(),
+        description: SwitchDescription(),
+        link: "https://api.flutter.dev/flutter/material/Switch-class.html",
       ),
+      WidgetModel(
         name: "TextField",
         subtitle: "Input field for username and password",
-        sample: TextFieldSample(),
-        sampleDescription: TextFielDescription(),
+        implementation: TextFieldImplementation(),
+        description: TextFielDescription(),
+        link: "https://api.flutter.dev/flutter/material/TextField-class.html",
       ),
       WidgetModel(
-          name: "Card",
-          sample: CardSample(),
-          sampleDescription: CardDescription()),
+        name: "Card",
+        implementation: CardImplementation(),
+        description: CardDescription(),
+        link: "https://api.flutter.dev/flutter/material/Card-class.html",
+      ),
       WidgetModel(
-          name: "Opacity",
-          sample: opacitysample(),
-          sampleDescription: opacitydescription()),
+        name: "Opacity",
+        implementation: OpacityImplementation(),
+        description: OpacityDescription(),
+        link: "https://api.flutter.dev/flutter/widgets/Opacity-class.html",
+      ),
       WidgetModel(
-          name: "Expanded",
-          sample: ExpandedSample(),
-          sampleDescription: ExpandedWidgetDescription()),
+        name: "Expanded",
+        implementation: ExpandedImplementation(),
+        description: ExpandedDescription(),
+        link: "https://api.flutter.dev/flutter/widgets/Expanded-class.html",
+      ),
     ];
 
     return ListView(
@@ -233,16 +259,10 @@ class HomePageState extends State<HomePage> {
         Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (_) => RootScreen(
-              widgetImplementation: item.sample,
-              widgetName: item.name,
-              widgetDescription: item.sampleDescription,
-            ),
+            builder: (_) => RootScreen(item),
           ),
         );
       },
     );
   }
-
-  constCardSample() {}
 }

--- a/lib/routes/Card.dart
+++ b/lib/routes/Card.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
-class CardSample extends StatefulWidget {
-  const CardSample({Key? key}) : super(key: key);
+class CardImplementation extends StatefulWidget {
+  const CardImplementation({Key? key}) : super(key: key);
 
   @override
-  _CardSampleState createState() => _CardSampleState();
+  _CardImplementationState createState() => _CardImplementationState();
 }
 
-class _CardSampleState extends State<CardSample> {
+class _CardImplementationState extends State<CardImplementation> {
   @override
   Widget build(BuildContext context) => Scaffold(
         // appBar: AppBar(

--- a/lib/routes/Root/rootScreen.dart
+++ b/lib/routes/Root/rootScreen.dart
@@ -1,16 +1,11 @@
+import 'package:fludget/Models/widgetModel.dart';
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class RootScreen extends StatefulWidget {
-  final Widget widgetImplementation;
-  final Widget widgetDescription;
-  final String widgetName;
+  final WidgetModel item;
 
-  RootScreen({
-    Key? key,
-    required this.widgetImplementation,
-    required this.widgetName,
-    required this.widgetDescription,
-  }) : super(key: key);
+  RootScreen(this.item, {Key? key}) : super(key: key);
 
   @override
   _RootScreenState createState() => _RootScreenState();
@@ -22,9 +17,13 @@ class _RootScreenState extends State<RootScreen> {
     return DefaultTabController(
       length: 2,
       child: Scaffold(
+        floatingActionButton: FloatingActionButton(
+          onPressed: () => _launchURL(widget.item.link),
+          child: Icon(Icons.link),
+        ),
         appBar: AppBar(
           backgroundColor: Colors.orange[900],
-          title: Text(widget.widgetName),
+          title: Text(widget.item.name),
           bottom: TabBar(
             tabs: [
               Tab(text: 'Implementation'),
@@ -34,8 +33,8 @@ class _RootScreenState extends State<RootScreen> {
         ),
         body: TabBarView(
           children: [
-            widget.widgetImplementation,
-            buildWidgetDescription(widget.widgetDescription),
+            widget.item.implementation,
+            buildDescription(widget.item.description),
           ],
         ),
       ),
@@ -43,7 +42,15 @@ class _RootScreenState extends State<RootScreen> {
   }
 }
 
-Widget buildWidgetDescription(Widget widgetDescription) {
+_launchURL(String url) async {
+  if (await canLaunch(url)) {
+    await launch(url);
+  } else {
+    throw 'Could not launch $url';
+  }
+}
+
+Widget buildDescription(Widget widgetDescription) {
   return Scaffold(
     backgroundColor: Colors.grey[900],
     body: widgetDescription,

--- a/lib/routes/Root/rootScreen.dart
+++ b/lib/routes/Root/rootScreen.dart
@@ -17,10 +17,6 @@ class _RootScreenState extends State<RootScreen> {
     return DefaultTabController(
       length: 2,
       child: Scaffold(
-        floatingActionButton: FloatingActionButton(
-          onPressed: () => _launchURL(widget.item.link),
-          child: Icon(Icons.link),
-        ),
         appBar: AppBar(
           backgroundColor: Colors.orange[900],
           title: Text(widget.item.name),
@@ -34,7 +30,7 @@ class _RootScreenState extends State<RootScreen> {
         body: TabBarView(
           children: [
             widget.item.implementation,
-            buildDescription(widget.item.description),
+            buildDescription(widget.item.description, widget.item.link),
           ],
         ),
       ),
@@ -50,9 +46,14 @@ _launchURL(String url) async {
   }
 }
 
-Widget buildDescription(Widget widgetDescription) {
+Widget buildDescription(Widget widgetDescription, String link) {
   return Scaffold(
     backgroundColor: Colors.grey[900],
     body: widgetDescription,
+    floatingActionButton: FloatingActionButton(
+      onPressed: () => _launchURL(link),
+      child: Icon(Icons.link),
+      backgroundColor: Colors.orange[900],
+    ),
   );
 }

--- a/lib/routes/button.dart
+++ b/lib/routes/button.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class ButtonSample extends StatelessWidget {
-  const ButtonSample({Key? key}) : super(key: key);
+class ButtonImplementation extends StatelessWidget {
+  const ButtonImplementation({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/column.dart
+++ b/lib/routes/column.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class ColumnSample extends StatelessWidget {
-  const ColumnSample({Key? key}) : super(key: key);
+class ColumnImplementation extends StatelessWidget {
+  const ColumnImplementation({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/dialogBox.dart
+++ b/lib/routes/dialogBox.dart
@@ -2,8 +2,8 @@
 
 import 'package:flutter/material.dart';
 
-class DialogBox extends StatelessWidget {
-  const DialogBox({Key? key}) : super(key: key);
+class DialogBoxImplementation extends StatelessWidget {
+  const DialogBoxImplementation({Key? key}) : super(key: key);
   Widget _buildDelDialog(BuildContext context) {
     return new AlertDialog(
       title: const Text('This is title'),

--- a/lib/routes/expanded.dart
+++ b/lib/routes/expanded.dart
@@ -1,8 +1,8 @@
 import 'package:fludget/constants/colors.dart';
 import 'package:flutter/material.dart';
 
-class ExpandedSample extends StatelessWidget {
-  const ExpandedSample({Key? key}) : super(key: key);
+class ExpandedImplementation extends StatelessWidget {
+  const ExpandedImplementation({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -128,8 +128,8 @@ class ExpandedSample extends StatelessWidget {
   }
 }
 
-class ExpandedWidgetDescription extends StatelessWidget {
-  const ExpandedWidgetDescription({Key? key}) : super(key: key);
+class ExpandedDescription extends StatelessWidget {
+  const ExpandedDescription({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/gridList.dart
+++ b/lib/routes/gridList.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class GridListSample extends StatelessWidget {
-  const GridListSample({Key? key}) : super(key: key);
+class GridListImplementation extends StatelessWidget {
+  const GridListImplementation({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/icon.dart
+++ b/lib/routes/icon.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class IconSample extends StatelessWidget {
-  const IconSample({Key? key}) : super(key: key);
+class IconImplementation extends StatelessWidget {
+  const IconImplementation({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -33,8 +33,8 @@ class IconSample extends StatelessWidget {
   }
 }
 
-class IconWidgetDescription extends StatelessWidget {
-  const IconWidgetDescription({Key? key}) : super(key: key);
+class IconDescription extends StatelessWidget {
+  const IconDescription({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/image.dart
+++ b/lib/routes/image.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class ImageSample extends StatelessWidget {
-  const ImageSample({Key? key}) : super(key: key);
+class ImageImplementation extends StatelessWidget {
+  const ImageImplementation({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -43,8 +43,8 @@ class ImageSample extends StatelessWidget {
   }
 }
 
-class ImageWidgetDescription extends StatelessWidget {
-  const ImageWidgetDescription({Key? key}) : super(key: key);
+class ImageDescription extends StatelessWidget {
+  const ImageDescription({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/opacity.dart
+++ b/lib/routes/opacity.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
-class opacitysample extends StatefulWidget {
-  const opacitysample({Key? key}) : super(key: key);
+class OpacityImplementation extends StatefulWidget {
+  const OpacityImplementation({Key? key}) : super(key: key);
 
   @override
-  _opacitysampleState createState() => _opacitysampleState();
+  _OpacityImplementationState createState() => _OpacityImplementationState();
 }
 
-class _opacitysampleState extends State<opacitysample> {
+class _OpacityImplementationState extends State<OpacityImplementation> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -159,14 +159,14 @@ class _opacitysampleState extends State<opacitysample> {
   }
 }
 
-class opacitydescription extends StatefulWidget {
-  const opacitydescription({Key? key}) : super(key: key);
+class OpacityDescription extends StatefulWidget {
+  const OpacityDescription({Key? key}) : super(key: key);
 
   @override
-  _opacitydescriptionState createState() => _opacitydescriptionState();
+  _OpacityDescriptionState createState() => _OpacityDescriptionState();
 }
 
-class _opacitydescriptionState extends State<opacitydescription> {
+class _OpacityDescriptionState extends State<OpacityDescription> {
   @override
   Widget build(BuildContext context) {
     return Center(

--- a/lib/routes/row.dart
+++ b/lib/routes/row.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class RowSample extends StatelessWidget {
-  const RowSample({Key? key}) : super(key: key);
+class RowImplementation extends StatelessWidget {
+  const RowImplementation({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -48,8 +48,8 @@ class RowSample extends StatelessWidget {
   }
 }
 
-class RowWidgetDescription extends StatelessWidget {
-  const RowWidgetDescription({Key? key}) : super(key: key);
+class RowDescription extends StatelessWidget {
+  const RowDescription({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/stack.dart
+++ b/lib/routes/stack.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class StackSample extends StatelessWidget {
-  const StackSample({Key? key}) : super(key: key);
+class StackImplementation extends StatelessWidget {
+  const StackImplementation({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -47,8 +47,8 @@ class StackSample extends StatelessWidget {
   }
 }
 
-class StackWidgetDescription extends StatelessWidget {
-  const StackWidgetDescription({Key? key}) : super(key: key);
+class StackDescription extends StatelessWidget {
+  const StackDescription({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/switch.dart
+++ b/lib/routes/switch.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 
-class SwitchSample extends StatefulWidget {
-  const SwitchSample({Key? key}) : super(key: key);
+class SwitchImplementation extends StatefulWidget {
+  const SwitchImplementation({Key? key}) : super(key: key);
   @override
-  _SwitchSampleState createState() => _SwitchSampleState();
+  _SwitchImplementationState createState() => _SwitchImplementationState();
 }
 
-class _SwitchSampleState extends State<SwitchSample> {
+class _SwitchImplementationState extends State<SwitchImplementation> {
   bool _isOn = false;
   void _toggleSwitch(bool newValue) {
     setState(() {

--- a/lib/routes/text.dart
+++ b/lib/routes/text.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class TextSample extends StatelessWidget {
-  const TextSample({Key? key}) : super(key: key);
+class TextImplementation extends StatelessWidget {
+  const TextImplementation({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -22,8 +22,8 @@ class TextSample extends StatelessWidget {
   }
 }
 
-class TextWidgetDescription extends StatelessWidget {
-  const TextWidgetDescription({Key? key}) : super(key: key);
+class TextDescription extends StatelessWidget {
+  const TextDescription({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/textfield.dart
+++ b/lib/routes/textfield.dart
@@ -2,8 +2,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-class TextFieldSample extends StatelessWidget {
-  const TextFieldSample({Key? key}) : super(key: key);
+class TextFieldImplementation extends StatelessWidget {
+  const TextFieldImplementation({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -67,6 +67,18 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.3"
   matcher:
     dependency: transitive
     description:
@@ -88,6 +100,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -142,6 +161,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.10"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   vector_math:
     dependency: transitive
     description:
@@ -151,3 +212,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
+  flutter: ">=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  url_launcher: ^6.0.10
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR addresses issue #25

The changes made:
Added support for AndroidX
Fix Naming convention widgets from ...WidgetSample to ...Implementation
Added links to existing widgets
Added floating action button in details of widgets

Here is a screenshot showing the floating action button

![Screenshot_20211004-181111](https://user-images.githubusercontent.com/42704349/135898820-2a4e6963-f311-407a-81ae-dba0fac28196.jpg)

Hacktoberfest Contribution