### PR TITLE
Added clear button in the search bar

### DIFF
--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -16,6 +16,7 @@ class HomePageState extends State<HomePage> {
   String searchString = '';
   WidgetCategoy? _selectedCategory;
   bool _isExpanded = false;
+  var _controller = TextEditingController();
 
   AppBar showSearchBar(BuildContext context) {
     return AppBar(
@@ -24,6 +25,7 @@ class HomePageState extends State<HomePage> {
       title: TextField(
         keyboardType: TextInputType.text,
         autofocus: true,
+        controller: _controller,
         decoration: InputDecoration(
           hintStyle: TextStyle(color: Colors.grey),
           prefixIcon: IconButton(
@@ -34,6 +36,15 @@ class HomePageState extends State<HomePage> {
                 searchString = '';
               });
             },
+          ),
+          suffixIcon: IconButton(
+            onPressed: (){
+              _controller.clear();
+              setState(() {
+                searchString = '';
+              });
+            },
+            icon: Icon(Icons.clear),
           ),
           hintText: 'Search....',
           border: UnderlineInputBorder(borderSide: BorderSide.none),
@@ -171,7 +182,6 @@ class HomePageState extends State<HomePage> {
   }
 
   ListView getWidgetList(String filter, BuildContext context) {
-
     List<WidgetModel> widgetList = List.from(widgets);
     widgetList.sort((a, b) => a.name.compareTo(b.name));
 


### PR DESCRIPTION
#153 

**The clear button was added successfully to the search bar.** 
Whenever clicked, it clears the text field and also resets the data that was searched.

Screenshots of the same are as follows: 

- Initial state:
![IMG_20211014_120734](https://user-images.githubusercontent.com/60578902/137265359-474b506d-a8c0-4424-a370-063d373c1382.jpg)

- If the search button is clicked:
![IMG_20211014_120653](https://user-images.githubusercontent.com/60578902/137265010-1d4e79e6-5279-44f5-b769-fda15eb38485.jpg)

- Type something into the search bar:
![IMG_20211014_120722](https://user-images.githubusercontent.com/60578902/137265022-79f58ce9-2007-45a4-a277-09634951c63d.jpg)

- If we click on the cross button, it clears the field: 
![IMG_20211014_120653](https://user-images.githubusercontent.com/60578902/137265010-1d4e79e6-5279-44f5-b769-fda15eb38485.jpg)

### **Thank you**