### PR TITLE
Fix #145: Add SingleChildScrollView Widget

### DIFF
--- a/lib/routes/singleChildScrollView.dart
+++ b/lib/routes/singleChildScrollView.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+class SingleChildScrollViewImplementation extends StatelessWidget {
+  const SingleChildScrollViewImplementation({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        body: Row(children: [
+      SingleChildScrollView(
+        padding: EdgeInsets.all(5.0),
+        child: Center(
+          child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Text("With SingleChildScrollView"),
+                SizedBox(height: 10),
+                Container(
+                    color: const Color(0xffeeee00),
+                    width: 150.0,
+                    height: 300.0,
+                    child: Center(child: Text('Item 1'))),
+                SizedBox(height: 10.0),
+                Container(
+                    color: const Color(0xffee0000),
+                    width: 200.0,
+                    height: 300.0,
+                    child: Center(child: Text('Item 2'))),
+                SizedBox(height: 10.0),
+                Container(
+                    color: const Color(0xff3fee00),
+                    width: 100.0,
+                    height: 400.0,
+                    child: Center(child: Text('Item 3'))),
+              ]),
+        ),
+      ),
+      Center(
+        child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
+              Text("Without SingleChildScrollView"),
+              SizedBox(height: 10),
+              Container(
+                  color: const Color(0xffeeee00),
+                  width: 150.0,
+                  height: 300.0,
+                  child: Center(child: Text('Item 1'))),
+              SizedBox(height: 10.0),
+              Container(
+                  color: const Color(0xffee0000),
+                  width: 200.0,
+                  height: 300.0,
+                  child: Center(child: Text('Item 2'))),
+              SizedBox(height: 10.0),
+              Container(
+                  color: const Color(0xff3fee00),
+                  width: 100.0,
+                  height: 400.0,
+                  child: Center(child: Text('Item 3'))),
+            ]),
+      )
+    ]));
+  }
+}
+
+class SingleChildScrollViewDescription extends StatelessWidget {
+  const SingleChildScrollViewDescription({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(children: [
+      SizedBox(height: 20),
+      Text('SingleChildScrollView Widget',
+          style: TextStyle(fontWeight: FontWeight.w800)),
+      SizedBox(height: 10),
+      Padding(
+        padding: const EdgeInsets.all(10.0),
+        child: Center(
+          child: Text(
+            'A box in which a single widget can be scrolled. This widget is useful when you have a single box that will normally be entirely visible, for example a clock face in a time picker, but you need to make sure it can be scrolled if the container gets too small in one axis (the scroll direction).',
+          ),
+        ),
+      )
+    ]);
+  }
+}

--- a/lib/widgetList.dart
+++ b/lib/widgetList.dart
@@ -48,6 +48,7 @@ import 'package:fludget/routes/reorderableListView.dart';
 import 'package:fludget/routes/richText.dart';
 import 'package:fludget/routes/row.dart';
 import 'package:fludget/routes/scrollbar.dart';
+import 'package:fludget/routes/singleChildScrollView.dart';
 import 'package:fludget/routes/sizedbox.dart';
 import 'package:fludget/routes/slider.dart';
 import 'package:fludget/routes/sliver_grid.dart';
@@ -536,5 +537,12 @@ const List<WidgetModel> widgets = [
       WidgetCategoy.Painting,
       WidgetCategoy.Styling,
     ],
+  ),
+  WidgetModel(
+    name: "SingleChildScrollView",
+    link: "https://api.flutter.dev/flutter/widgets/SingleChildScrollView-class.html",
+    implementation: SingleChildScrollViewImplementation(),
+    description:SingleChildScrollViewDescription(),
+    category: [ WidgetCategoy.Scrolling ]
   )
 ];


### PR DESCRIPTION
Implemented a row containing two columns to show the need for `SingleChildScrollView` 
Solves #145 

![image](https://user-images.githubusercontent.com/55327432/137610620-546cbe1b-c060-4fa0-a71f-f9f213b28a30.png)

![image](https://user-images.githubusercontent.com/55327432/137610624-8847eff0-22d4-4d0f-b729-eba59cb68cf3.png)

![image](https://user-images.githubusercontent.com/55327432/137610628-a3825abc-c79d-439c-bcdf-f714cbfcafc3.png)

![image](https://user-images.githubusercontent.com/55327432/137610693-3caabc19-0b4b-432b-809b-16af3cbdcf49.png)
